### PR TITLE
Bump Ruby and Bundler versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && \
       ruby-io-console \
       ruby-irb \
       ruby-rake
-
+RUN gem install bundler
 COPY Gemfile* /tmp/
 WORKDIR /tmp
 RUN bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ DEPENDENCIES
   s3_website (~> 3.1.0)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.6.5
 
 BUNDLED WITH
-   1.15.0
+   2.1.4


### PR DESCRIPTION
## What's changed?

Newer version of the Docker image used for the S3 deployment pipeline come with newer Ruby and Bundler, so this updates the Gemfile.lock to reflect that (along with explicitly ensuring Bundler is installed) as otherwise Bundler fails to install.

This shouldn't cause issues for existing Docker containers since this only affects a new build, however it would be prudent to re-build these containers in any case.